### PR TITLE
fix: declare NWC_URL env var in metadata.openclaw.requires

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -5,6 +5,11 @@ license: Apache-2.0
 metadata:
   author: getAlby
   version: "1.2.1"
+  openclaw:
+    requires:
+      env:
+        - NWC_URL
+    primaryEnv: NWC_URL
 ---
 
 # Usage


### PR DESCRIPTION
## What

Add NWC_URL to metadata.openclaw.requires.env in SKILL.md frontmatter, per the ClawHub skill-format spec.

## Why

ClawHub scanner flagged 'Metadata declares no required env vars' — declaring NWC_URL formally tells the scanner wallet credentials are intentional access, not hidden surprises.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI package version reference to `@getalby/cli@0.6.1`.
  * Updated license to MIT-0.
  * Added `NWC_URL` environment variable requirement documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->