### PR TITLE
fix: declare NWC_URL env var in metadata.openclaw.requires

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -11,7 +11,11 @@ metadata:
         - NWC_URL
       bins:
         - npx
+      config:
+        - ~/.alby-cli/
     primaryEnv: NWC_URL
+    emoji: "🐝"
+    homepage: https://getalby.com
 ---
 
 # Usage

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,6 +5,13 @@ license: MIT-0
 metadata:
   author: getAlby
   version: "1.2.2"
+  openclaw:
+    requires:
+      env:
+        - NWC_URL
+      bins:
+        - npx
+    primaryEnv: NWC_URL
 ---
 
 # Usage

--- a/SKILL.md
+++ b/SKILL.md
@@ -4,7 +4,7 @@ description: teaches agents how to use @getalby/cli for bitcoin lightning wallet
 license: MIT-0
 metadata:
   author: getAlby
-  version: "1.2.2"
+  version: "1.2.3"
   openclaw:
     requires:
       env:


### PR DESCRIPTION
## What

Add `NWC_URL` to `metadata.openclaw.requires.env` in SKILL.md frontmatter, per the [ClawHub skill-format spec](https://github.com/openclaw/clawhub/blob/main/docs/skill-format.md).

## Why

ClawHub's scanner flagged the skill with a `Metadata declares no required env vars` warning — even though the skill uses `NWC_URL` (wallet connection secret). Declaring it formally tells the scanner this access is intentional, reducing the "surprise access" attack-surface flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.2.3
  * Updated skill configuration requirements, including environment variables and necessary setup directories
  * Added metadata for enhanced skill identification and homepage reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->