### PR TITLE
docs: l402.space bridge for x402/MPP services

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -111,10 +111,15 @@ As an absolute last resort, tell your human to visit [the Alby support page](htt
 
 You are **not** limited to lightning-native services. Endpoints priced in **USDC on Base or Solana** (x402) or **stablecoin on Tempo** (MPP) can be paid from your lightning wallet through a universal bridge at [l402.space](https://l402.space) — you pay the bridge over lightning and it forwards payment to the upstream over its own rail. Rails the bridge does not fund (e.g. Stellar, Polygon, Stripe) can't be paid this way.
 
-`discover` already returns every result ready to `fetch` (non-lightning ones are bridged for you, unpayable ones dropped), so you only need to wrap a URL by hand when you have a non-lightning endpoint **from elsewhere**: URL-encode the full upstream endpoint (including query params) and append it to `https://l402.space/`, then `fetch` that:
+`discover` already returns every result ready to `fetch` (non-lightning ones are bridged for you, unpayable ones dropped), so you only need to wrap a URL by hand when you have a non-lightning endpoint **from elsewhere**. URL-encode the full upstream endpoint (including query params) and append it to the bridge path that matches the upstream's protocol, then `fetch` that:
+
+- **x402** (USDC on Base/Solana): `https://l402.space/<url-encoded-upstream-url>`
+- **MPP** (stablecoin on Tempo): `https://l402.space/mpp-lightning/<url-encoded-upstream-url>`
+
+MPP **must** use the `mpp-lightning/` path — the plain path mislabels an MPP endpoint as x402 and the bridge will try to settle it over the wrong rail.
 
 ```bash
-npx -y @getalby/cli@0.9.0 fetch "https://l402.space/<url-encoded-upstream-url>" --max-amount <amount> --currency BTC --unit sats --network lightning
+npx -y @getalby/cli@0.9.0 fetch "https://l402.space/mpp-lightning/<url-encoded-upstream-url>" --max-amount <amount> --currency BTC --unit sats --network lightning
 ```
 
 Your HTTP method and body pass through unchanged. For full details and current behavior, read [https://l402.space/llms.txt](https://l402.space/llms.txt).

--- a/SKILL.md
+++ b/SKILL.md
@@ -4,7 +4,7 @@ description: teaches agents how to use @getalby/cli to operate a bitcoin lightni
 license: MIT-0
 metadata:
   author: getAlby
-  version: "1.3.8"
+  version: "1.3.9"
   openclaw:
     requires:
       env:
@@ -87,6 +87,7 @@ get-info, get-wallet-service-info, get-budget, lookup-invoice, sign-message, wai
 fetch — auto-detects L402, X402, and MPP payment protocols. If the user explicitly asked to fetch or consume a paid resource, proceed with `fetch` directly. If a 402 is encountered unexpectedly (e.g. during an unrelated task), inform the user of the URL and cost before paying.
 
 - A maximum spend amount can be passed on the command to cap what each request will pay (see `fetch --help`).
+- L402 services are paid directly from your lightning wallet. To pay an x402 or MPP service in sats, route it through the l402.space bridge (see [Paying x402 / MPP services in sats](#paying-x402--mpp-services-in-sats-l402space-bridge)).
 
 **Service Discovery (no wallet needed):**
 discover
@@ -108,7 +109,7 @@ As an absolute last resort, tell your human to visit [the Alby support page](htt
 
 ## Discovering Paid Services
 
-The `discover` command searches [402index.io](https://402index.io) for lightning-payable API endpoints. It only returns services that accept bitcoin/lightning payments.
+The `discover` command searches [402index.io](https://402index.io) for paid API endpoints across all protocols — L402, x402, and MPP. Lightning-native (L402) services can be paid directly with `fetch`; x402 and MPP services can be paid in sats by routing them through the l402.space bridge (see [Paying x402 / MPP services in sats](#paying-x402--mpp-services-in-sats-l402space-bridge) below). Each result includes a `protocol` and `payment_network` so you can tell which is which.
 
 ### When to use discover
 
@@ -125,11 +126,31 @@ The `discover` command searches [402index.io](https://402index.io) for lightning
 
 1. **Discover** — find services matching the capability gap
 2. **Evaluate** — check price, health status, and reliability from the results
-3. **Fetch** — pay and consume the service:
+3. **Fetch** — pay and consume the service. For L402 services pass the URL directly; for x402/MPP services route through the l402.space bridge (see below):
    ```bash
    npx -y @getalby/cli@0.8.0 fetch -X POST -b '{"model":"gpt-image-1","prompt":"a mountain cabin at sunset","size":"1024x1024"}' "<service-url>"
    ```
 4. **Report** — tell the user what was purchased, the cost, and the result
+
+### Paying x402 / MPP services in sats (l402.space bridge)
+
+`discover` and the wider web surface paid endpoints across all protocols. L402 services are lightning-native — pass their URL straight to `fetch`. x402 (USDC) and MPP services settle on other rails, but you can still pay them in sats by routing the request through the [l402.space](https://l402.space) bridge: it accepts a lightning payment from your wallet and settles the upstream cost on your behalf, so a single lightning balance is all you need.
+
+Wrap the upstream URL by URL-encoding it (query string included) and appending it to the bridge base:
+
+`https://l402.space/<url-encoded-upstream-url>`
+
+For example, to fetch the x402 endpoint `https://x402.twit.sh/tweets/user?username=getalby`:
+
+```bash
+npx -y @getalby/cli@0.8.0 fetch \
+  "https://l402.space/https%3A%2F%2Fx402.twit.sh%2Ftweets%2Fuser%3Fusername%3Dgetalby" \
+  --max-amount 5000 --currency BTC --unit sats --network lightning
+```
+
+The method, body, and headers you pass to `fetch` are forwarded to the upstream unchanged. The bridge replies with an L402 challenge, `fetch` pays it from your lightning wallet (subject to `--max-amount`), and returns the upstream response.
+
+Use the bridge whenever a service's `protocol` is `x402` or `MPP`, or its `payment_network` is not lightning. For L402 services, fetch the URL directly — no bridge needed.
 
 ## Bitcoin Units
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -87,7 +87,7 @@ get-info, get-wallet-service-info, get-budget, lookup-invoice, sign-message, wai
 fetch — auto-detects L402, X402, and MPP payment protocols. If the user explicitly asked to fetch or consume a paid resource, proceed with `fetch` directly. If a 402 is encountered unexpectedly (e.g. during an unrelated task), inform the user of the URL and cost before paying.
 
 - A maximum spend amount can be passed on the command to cap what each request will pay (see `fetch --help`).
-- L402 services are paid directly from your lightning wallet. To pay an x402 or MPP service in sats, route it through the l402.space bridge (see [Paying x402 / MPP services in sats](#paying-x402--mpp-services-in-sats-l402space-bridge)).
+- All protocols are paid from your lightning wallet with the same command. x402/USDC and MPP services are settled in sats automatically — you never need a stablecoin balance, and you always pass the service's own URL, never a special one.
 
 **Service Discovery (no wallet needed):**
 discover
@@ -109,7 +109,7 @@ As an absolute last resort, tell your human to visit [the Alby support page](htt
 
 ## Discovering Paid Services
 
-The `discover` command searches [402index.io](https://402index.io) for paid API endpoints across all protocols — L402, x402, and MPP. Lightning-native (L402) services can be paid directly with `fetch`; x402 and MPP services can be paid in sats by routing them through the l402.space bridge (see [Paying x402 / MPP services in sats](#paying-x402--mpp-services-in-sats-l402space-bridge) below). Each result includes a `protocol` and `payment_network` so you can tell which is which.
+The `discover` command searches [402index.io](https://402index.io) for paid API endpoints across all protocols — L402, x402, and MPP. All of them are payable in sats with `fetch`: lightning-native services are paid directly, and x402/MPP services are settled in sats automatically. Each result includes a `protocol` and `payment_network` so you know what you're calling.
 
 ### When to use discover
 
@@ -126,31 +126,11 @@ The `discover` command searches [402index.io](https://402index.io) for paid API 
 
 1. **Discover** — find services matching the capability gap
 2. **Evaluate** — check price, health status, and reliability from the results
-3. **Fetch** — pay and consume the service. For L402 services pass the URL directly; for x402/MPP services route through the l402.space bridge (see below):
+3. **Fetch** — pay and consume the service by passing its URL to `fetch`. Any protocol works; x402/MPP services are paid in sats automatically:
    ```bash
    npx -y @getalby/cli@0.8.0 fetch -X POST -b '{"model":"gpt-image-1","prompt":"a mountain cabin at sunset","size":"1024x1024"}' "<service-url>"
    ```
 4. **Report** — tell the user what was purchased, the cost, and the result
-
-### Paying x402 / MPP services in sats (l402.space bridge)
-
-`discover` and the wider web surface paid endpoints across all protocols. L402 services are lightning-native — pass their URL straight to `fetch`. x402 (USDC) and MPP services settle on other rails, but you can still pay them in sats by routing the request through the [l402.space](https://l402.space) bridge: it accepts a lightning payment from your wallet and settles the upstream cost on your behalf, so a single lightning balance is all you need.
-
-Wrap the upstream URL by URL-encoding it (query string included) and appending it to the bridge base:
-
-`https://l402.space/<url-encoded-upstream-url>`
-
-For example, to fetch the x402 endpoint `https://x402.twit.sh/tweets/user?username=getalby`:
-
-```bash
-npx -y @getalby/cli@0.8.0 fetch \
-  "https://l402.space/https%3A%2F%2Fx402.twit.sh%2Ftweets%2Fuser%3Fusername%3Dgetalby" \
-  --max-amount 5000 --currency BTC --unit sats --network lightning
-```
-
-The method, body, and headers you pass to `fetch` are forwarded to the upstream unchanged. The bridge replies with an L402 challenge, `fetch` pays it from your lightning wallet (subject to `--max-amount`), and returns the upstream response.
-
-Use the bridge whenever a service's `protocol` is `x402` or `MPP`, or its `payment_network` is not lightning. For L402 services, fetch the URL directly — no bridge needed.
 
 ## Bitcoin Units
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -4,7 +4,7 @@ description: teaches agents how to use @getalby/cli to operate a bitcoin lightni
 license: MIT-0
 metadata:
   author: getAlby
-  version: "1.4.0"
+  version: "1.4.1"
   openclaw:
     requires:
       env:
@@ -109,9 +109,9 @@ As an absolute last resort, tell your human to visit [the Alby support page](htt
 
 ## Paying Non-Lightning 402 Services
 
-You are **not** limited to lightning-native services. Any x402 (USDC), MPP (Tempo), or L402 endpoint can be paid from your lightning wallet through a universal bridge at [l402.space](https://l402.space) — you pay the bridge over lightning and it forwards payment to the upstream over whichever rail it speaks.
+You are **not** limited to lightning-native services. Endpoints priced in **USDC on Base or Solana** (x402) or **stablecoin on Tempo** (MPP) can be paid from your lightning wallet through a universal bridge at [l402.space](https://l402.space) — you pay the bridge over lightning and it forwards payment to the upstream over its own rail. Rails the bridge does not fund (e.g. Stellar, Polygon, Stripe) can't be paid this way.
 
-The bridge URL is not auto-detected — you must encode it yourself: URL-encode the full upstream endpoint (including query params) and append it to `https://l402.space/`, then `fetch` that:
+`discover` already returns bridgeable services with their `l402.space` URL in place (see below), so you normally just `fetch` the URL from the results. You only need to wrap a URL by hand when you have a non-lightning endpoint from elsewhere: URL-encode the full upstream endpoint (including query params) and append it to `https://l402.space/`, then `fetch` that:
 
 ```bash
 npx -y @getalby/cli@0.9.0 fetch "https://l402.space/<url-encoded-upstream-url>" --max-amount <amount> --currency BTC --unit sats --network lightning
@@ -121,7 +121,7 @@ Your HTTP method and body pass through unchanged. For full details and current b
 
 ## Discovering Paid Services
 
-The `discover` command searches [402index.io](https://402index.io) for paid API endpoints across all supported rails — L402, x402, and MPP. Do not filter by rail unless explicitly told by the human. Lightning-native services can be paid with `fetch` directly; for non-lightning services (x402/USDC, MPP/Tempo), pay them from your lightning wallet via the bridge described above.
+The `discover` command searches [402index.io](https://402index.io) for paid API endpoints across all supported rails — L402, x402, and MPP. Do not filter by rail unless explicitly told by the human. Results are returned ready to pay: lightning-native services (L402, or anything on the Lightning rail) keep their own URL, and services on a bridge-funded rail (USDC on Base/Solana, stablecoin on Tempo) come back with their `l402.space` URL already set. Either way, just pass the result's `url` to `fetch`. Services on rails the bridge can't settle (e.g. Stellar, Polygon, Stripe) are returned with their native URL and aren't payable from a lightning wallet.
 
 ### When to use discover
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -137,7 +137,7 @@ The `discover` command searches [402index.io](https://402index.io) for paid API 
 ### Discover → Fetch flow
 
 1. **Discover** — find services matching the capability gap
-2. **Evaluate** — check health status and reliability from the results. Price (`price_sats`/`price_usd`) is often `null` — many services don't publish one up front, so you may not learn the cost until the `402` challenge at fetch time. Use `--max-amount` to cap the spend when the price is unknown.
+2. **Evaluate** — check health status and reliability from the results. Treat listed prices as hints only: they can be missing or outdated. The real price is set by the `402` challenge at fetch time, and `fetch` refuses to pay more than its `--max-amount` cap (default: 5000 sats).
 3. **Fetch** — pay and consume the service by passing its URL to `fetch`:
    ```bash
    npx -y @getalby/cli@0.9.0 fetch -X POST -b '{"model":"gpt-image-1","prompt":"a mountain cabin at sunset","size":"1024x1024"}' "<service-url>"

--- a/SKILL.md
+++ b/SKILL.md
@@ -142,7 +142,7 @@ The `discover` command searches [402index.io](https://402index.io) for paid API 
 ### Discover → Fetch flow
 
 1. **Discover** — find services matching the capability gap
-2. **Evaluate** — check price, health status, and reliability from the results
+2. **Evaluate** — check health status and reliability from the results. Price (`price_sats`/`price_usd`) is often `null` — many services don't publish one up front, so you may not learn the cost until the `402` challenge at fetch time. Use `--max-amount` to cap the spend when the price is unknown.
 3. **Fetch** — pay and consume the service by passing its URL to `fetch`:
    ```bash
    npx -y @getalby/cli@0.9.0 fetch -X POST -b '{"model":"gpt-image-1","prompt":"a mountain cabin at sunset","size":"1024x1024"}' "<service-url>"

--- a/SKILL.md
+++ b/SKILL.md
@@ -111,7 +111,7 @@ As an absolute last resort, tell your human to visit [the Alby support page](htt
 
 You are **not** limited to lightning-native services. Endpoints priced in **USDC on Base or Solana** (x402) or **stablecoin on Tempo** (MPP) can be paid from your lightning wallet through a universal bridge at [l402.space](https://l402.space) — you pay the bridge over lightning and it forwards payment to the upstream over its own rail. Rails the bridge does not fund (e.g. Stellar, Polygon, Stripe) can't be paid this way.
 
-`discover` already returns bridgeable services with their `l402.space` URL in place (see below), so you normally just `fetch` the URL from the results. You only need to wrap a URL by hand when you have a non-lightning endpoint from elsewhere: URL-encode the full upstream endpoint (including query params) and append it to `https://l402.space/`, then `fetch` that:
+`discover` already returns every result ready to `fetch` (non-lightning ones are bridged for you, unpayable ones dropped), so you only need to wrap a URL by hand when you have a non-lightning endpoint **from elsewhere**: URL-encode the full upstream endpoint (including query params) and append it to `https://l402.space/`, then `fetch` that:
 
 ```bash
 npx -y @getalby/cli@0.9.0 fetch "https://l402.space/<url-encoded-upstream-url>" --max-amount <amount> --currency BTC --unit sats --network lightning
@@ -121,7 +121,7 @@ Your HTTP method and body pass through unchanged. For full details and current b
 
 ## Discovering Paid Services
 
-The `discover` command searches [402index.io](https://402index.io) for paid API endpoints across all supported rails — L402, x402, and MPP. Do not filter by rail unless explicitly told by the human. Results are returned ready to pay: lightning-native services (L402, or anything on the Lightning rail) keep their own URL, and services on a bridge-funded rail (USDC on Base/Solana, stablecoin on Tempo) come back with their `l402.space` URL already set. Either way, just pass the result's `url` to `fetch`. Services on rails the bridge can't settle (e.g. Stellar, Polygon, Stripe) are returned with their native URL and aren't payable from a lightning wallet.
+The `discover` command searches [402index.io](https://402index.io) for paid API endpoints across L402, x402, and MPP. Every result is payable in sats — just pass its `url` to `fetch`. Do not filter by rail unless explicitly told by the human.
 
 ### When to use discover
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -84,7 +84,7 @@ auth, connect
 get-info, get-wallet-service-info, get-budget, lookup-invoice, sign-message, wait-for-payment, list-wallets
 
 **HTTP 402 Payments:**
-fetch — pay for and retrieve a payment-protected (HTTP 402) resource, paying the cost in sats from your lightning wallet. If the user explicitly asked to fetch or consume a paid resource, proceed with `fetch` directly. If a 402 is encountered unexpectedly (e.g. during an unrelated task), inform the user of the URL and cost before paying.
+fetch — pay for and retrieve a payment-protected (HTTP 402) resource. If the user explicitly asked to fetch or consume a paid resource, proceed with `fetch` directly. If a 402 is encountered unexpectedly (e.g. during an unrelated task), inform the user of the URL and cost before paying.
 
 - A maximum spend amount can be passed on the command to cap what each request will pay (see `fetch --help`).
 
@@ -108,7 +108,7 @@ As an absolute last resort, tell your human to visit [the Alby support page](htt
 
 ## Discovering Paid Services
 
-The `discover` command searches [402index.io](https://402index.io) for paid API endpoints. Pay for any of them in sats with the `fetch` command.
+The `discover` command searches [402index.io](https://402index.io) for paid API endpoints. Pay for any of them with the `fetch` command.
 
 ### When to use discover
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -111,15 +111,10 @@ As an absolute last resort, tell your human to visit [the Alby support page](htt
 
 You are **not** limited to lightning-native services. Endpoints priced in **USDC on Base or Solana** (x402) or **stablecoin on Tempo** (MPP) can be paid from your lightning wallet through a universal bridge at [l402.space](https://l402.space) — you pay the bridge over lightning and it forwards payment to the upstream over its own rail. Rails the bridge does not fund (e.g. Stellar, Polygon, Stripe) can't be paid this way.
 
-`discover` already returns every result ready to `fetch` (non-lightning ones are bridged for you, unpayable ones dropped), so you only need to wrap a URL by hand when you have a non-lightning endpoint **from elsewhere**. URL-encode the full upstream endpoint (including query params) and append it to the bridge path that matches the upstream's protocol, then `fetch` that:
-
-- **x402** (USDC on Base/Solana): `https://l402.space/<url-encoded-upstream-url>`
-- **MPP** (stablecoin on Tempo): `https://l402.space/mpp-lightning/<url-encoded-upstream-url>`
-
-MPP **must** use the `mpp-lightning/` path — the plain path mislabels an MPP endpoint as x402 and the bridge will try to settle it over the wrong rail.
+`discover` already returns every result ready to `fetch` (non-lightning ones are bridged for you, unpayable ones dropped), so you only need to wrap a URL by hand when you have a non-lightning endpoint **from elsewhere**: URL-encode the full upstream endpoint (including query params) and append it to `https://l402.space/`, then `fetch` that. The same path works for x402 and MPP upstreams alike — the gateway detects the upstream's protocol itself. An x402/MPP endpoint that supports lightning natively needs no bridge at all; just `fetch` it directly.
 
 ```bash
-npx -y @getalby/cli@0.9.0 fetch "https://l402.space/mpp-lightning/<url-encoded-upstream-url>" --max-amount <amount> --currency BTC --unit sats --network lightning
+npx -y @getalby/cli@0.9.0 fetch "https://l402.space/<url-encoded-upstream-url>" --max-amount <amount> --currency BTC --unit sats --network lightning
 ```
 
 Your HTTP method and body pass through unchanged. For full details and current behavior, read [https://l402.space/llms.txt](https://l402.space/llms.txt).

--- a/SKILL.md
+++ b/SKILL.md
@@ -84,10 +84,9 @@ auth, connect
 get-info, get-wallet-service-info, get-budget, lookup-invoice, sign-message, wait-for-payment, list-wallets
 
 **HTTP 402 Payments:**
-fetch — auto-detects L402, X402, and MPP payment protocols. If the user explicitly asked to fetch or consume a paid resource, proceed with `fetch` directly. If a 402 is encountered unexpectedly (e.g. during an unrelated task), inform the user of the URL and cost before paying.
+fetch — pay for and retrieve a payment-protected (HTTP 402) resource, paying the cost in sats from your lightning wallet. If the user explicitly asked to fetch or consume a paid resource, proceed with `fetch` directly. If a 402 is encountered unexpectedly (e.g. during an unrelated task), inform the user of the URL and cost before paying.
 
 - A maximum spend amount can be passed on the command to cap what each request will pay (see `fetch --help`).
-- All protocols are paid from your lightning wallet with the same command. x402/USDC and MPP services are settled in sats automatically — you never need a stablecoin balance, and you always pass the service's own URL, never a special one.
 
 **Service Discovery (no wallet needed):**
 discover
@@ -109,7 +108,7 @@ As an absolute last resort, tell your human to visit [the Alby support page](htt
 
 ## Discovering Paid Services
 
-The `discover` command searches [402index.io](https://402index.io) for paid API endpoints across all protocols — L402, x402, and MPP. All of them are payable in sats with `fetch`: lightning-native services are paid directly, and x402/MPP services are settled in sats automatically. Each result includes a `protocol` and `payment_network` so you know what you're calling.
+The `discover` command searches [402index.io](https://402index.io) for paid API endpoints. Pay for any of them in sats with the `fetch` command.
 
 ### When to use discover
 
@@ -126,7 +125,7 @@ The `discover` command searches [402index.io](https://402index.io) for paid API 
 
 1. **Discover** — find services matching the capability gap
 2. **Evaluate** — check price, health status, and reliability from the results
-3. **Fetch** — pay and consume the service by passing its URL to `fetch`. Any protocol works; x402/MPP services are paid in sats automatically:
+3. **Fetch** — pay and consume the service by passing its URL to `fetch`:
    ```bash
    npx -y @getalby/cli@0.8.0 fetch -X POST -b '{"model":"gpt-image-1","prompt":"a mountain cabin at sunset","size":"1024x1024"}' "<service-url>"
    ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alby-bitcoin-payments
-description: teaches agents how to use @getalby/cli to operate a bitcoin lightning wallet via Nostr Wallet Connect (NIP-47). Use whenever the user wants to send or receive money, pay an invoice, check wallet balance, create invoices, convert between fiat and sats, retry an HTTP request that returned 402 Payment Required, or discover paid API services. Beyond lightning, it can pay to any on-chain cryptocurrency/stablecoin address (e.g. USDC/USDT) by automatically swapping from the bitcoin balance.
+description: teaches agents how to use @getalby/cli to operate a bitcoin lightning wallet via Nostr Wallet Connect (NIP-47). Use whenever the user wants to send or receive money, pay an invoice, check wallet balance, create invoices, convert between fiat and sats, retry an HTTP request that returned 402 Payment Required, or discover paid API services. Pays HTTP 402 resources across all major payment protocols - L402, x402, and MPP - from the lightning wallet. Beyond lightning, it can pay to any on-chain cryptocurrency/stablecoin address (e.g. USDC/USDT) by automatically swapping from the bitcoin balance.
 license: MIT-0
 metadata:
   author: getAlby


### PR DESCRIPTION
## What

Updates the skill now that the CLI pays **every** 402 protocol from a lightning wallet with a single command.

- `discover` returns services across all protocols (L402, x402, MPP); each result carries `protocol` and `payment_network`.
- `fetch <service-url>` pays any of them in sats — x402/USDC and MPP are settled in sats automatically. No manual URL-encoding, no special bridge URL, no stablecoin balance.
- Bump skill version 1.3.8 → 1.3.9.

## Why

Pairs with getAlby/cli#49 (refs getAlby/cli#26), which drops the lightning-only filter in `discover` and routes non-lightning endpoints through the l402.space bridge **internally**. The bridge is an implementation detail of `fetch`, so the skill just tells agents to fetch the service's own URL — earlier drafts that documented hand-encoding an `https://l402.space/<encoded-url>` proxy URL have been removed.

Refs getAlby/cli#26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Bitcoin payment agent guidance for handling HTTP 402 payment challenges.
  * Clarified compatibility limits for non-Lightning payment rails and unsupported upstream funding options.
  * Refined paid-service discovery and fetch instructions, including direct URL usage and pricing evaluation.
  * Updated the skill metadata version to 1.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## TODO before merge

- [ ] Cut a new @getalby/cli release including getAlby/cli#49 (discover pre-wraps bridgeable services), then bump the `@getalby/cli@0.9.0` version references in SKILL.md to it — until then the skill promises pre-wrapped discover URLs the pinned CLI doesn't produce.