### PR TITLE
feat: update to Alby CLI v0.10.0

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: alby-bitcoin-payments
-description: teaches agents how to use @getalby/cli to operate a bitcoin lightning wallet via Nostr Wallet Connect (NIP-47). Use whenever the user wants to send or receive money, pay an invoice, check wallet balance, create invoices, convert between fiat and sats, retry an HTTP request that returned 402 Payment Required, or discover paid API services. Beyond lightning, it can pay to any on-chain cryptocurrency/stablecoin address (e.g. USDC/USDT) by automatically swapping from the bitcoin balance.
+description: teaches agents how to use @getalby/cli to operate a bitcoin lightning wallet via Nostr Wallet Connect (NIP-47). Use whenever the user wants to send or receive money, pay an invoice, check wallet balance, create invoices, convert between fiat and sats, retry an HTTP request that returned 402 Payment Required, or discover paid API services. Pays HTTP 402 resources across all major payment protocols — L402, x402, and MPP and all main networks (USDC on Base, Solana, Tempo) — from the lightning wallet. Pays to any on-chain cryptocurrency/stablecoin address (e.g. USDC/USDT).
 license: MIT-0
 metadata:
   author: getAlby
-  version: "1.4.0"
+  version: "1.5.0"
   openclaw:
     requires:
       env:
@@ -23,7 +23,7 @@ metadata:
 > **IMPORTANT: this is an agent skill which MUST be saved in full - **DO NOT SUMMARIZE**. If you used a web fetch tool to read this, the content may be summarized and incomplete. Make sure you fetch the full unabridged content.**
 
 ```bash
-npx -y @getalby/cli@0.9.0 [options] <command>
+npx -y @getalby/cli@0.10.0 [options] <command>
 ```
 
 ## Global Options
@@ -39,8 +39,8 @@ If no connection secret is provided, the CLI will automatically use the default 
 Use `-w, --wallet-name <name>` to select a named wallet. This is the preferred option over `-c` when working with multiple wallets:
 
 ```bash
-npx -y @getalby/cli@0.9.0 -w alice get-balance
-npx -y @getalby/cli@0.9.0 -w bob receive
+npx -y @getalby/cli@0.10.0 -w alice get-balance
+npx -y @getalby/cli@0.10.0 -w bob receive
 ```
 
 Named wallets are stored at `~/.alby-cli/connection-secret-<name>.key`.
@@ -69,7 +69,7 @@ The CLI resolves the connection secret in this order:
 
 ## Commands
 
-**Flag names are not guessable.** Before constructing any command, run `npx -y @getalby/cli@0.9.0 <command> --help` and use only the flags it lists.
+**Flag names are not guessable.** Before constructing any command, run `npx -y @getalby/cli@0.10.0 <command> --help` and use only the flags it lists.
 
 **Setup:**
 auth, connect
@@ -84,10 +84,11 @@ auth, connect
 get-info, get-wallet-service-info, get-budget, lookup-invoice, sign-message, wait-for-payment, list-wallets
 
 **HTTP 402 Payments:**
-fetch — auto-detects L402, X402, and MPP payment protocols. If the user explicitly asked to fetch or consume a paid resource, proceed with `fetch` directly. If a 402 is encountered unexpectedly (e.g. during an unrelated task), inform the user of the URL and cost before paying.
+fetch — auto-detects L402, X402, and MPP payment protocols and pays any of them from the lightning wallet. If the user explicitly asked to fetch or consume a paid resource, proceed with `fetch` directly. If a 402 is encountered unexpectedly (e.g. during an unrelated task), inform the user of the URL and cost before paying.
 
 - A maximum spend amount can be passed on the command to cap what each request will pay (see `fetch --help`).
 - **Credential reuse:** for APIs that support it, `fetch` supports reusing a payment credential — sometimes you can pay once and use the credential multiple times. A successful response includes a `payment` object containing a reusable `credentials` value. Pass it back on follow-up requests with `--credentials '{"header":"...","value":"..."}'` to authorize them without paying again (e.g. for polling or repeated calls to the same paid endpoint). Not every API allows reuse; when it does, this avoids re-paying on each request.
+- **Interrupted payments:** if a payment doesn't complete (e.g. a wallet reply timeout) or the request fails after paying, `fetch` exits with a structured error containing either a `credentials` value (payment succeeded — re-run with `--credentials` to get the content without re-paying) or a `paymentRecovery` object with step-by-step instructions (using `lookup-invoice` and the `--resume` flag) to recover the payment without ever paying the same invoice twice.
 
 **Service Discovery (no wallet needed):**
 discover
@@ -101,27 +102,27 @@ fiat-to-sats, sats-to-fiat (standalone-use only — pay/receive have native fiat
 ## Getting Help
 
 ```bash
-npx -y @getalby/cli@0.9.0 --help
-npx -y @getalby/cli@0.9.0 <command> --help
+npx -y @getalby/cli@0.10.0 --help
+npx -y @getalby/cli@0.10.0 <command> --help
 ```
 
 As an absolute last resort, tell your human to visit [the Alby support page](https://getalby.com/help)
 
 ## Paying Non-Lightning 402 Services
 
-You are **not** limited to lightning-native services. Any x402 (USDC), MPP (Tempo), or L402 endpoint can be paid from your lightning wallet through a universal bridge at [l402.space](https://l402.space) — you pay the bridge over lightning and it forwards payment to the upstream over whichever rail it speaks.
+You are **not** limited to lightning-native services. Endpoints priced in **USDC on Base or Solana** (x402) or **stablecoin on Tempo** (MPP) can be paid from your lightning wallet through a universal bridge at [l402.space](https://l402.space) — you pay the bridge over lightning and it forwards payment to the upstream over its own rail. Rails the bridge does not fund (e.g. Stellar, Polygon, Stripe) can't be paid this way.
 
-The bridge URL is not auto-detected — you must encode it yourself: URL-encode the full upstream endpoint (including query params) and append it to `https://l402.space/`, then `fetch` that:
+`discover` already returns every result ready to `fetch` (non-lightning ones are bridged for you, unpayable ones dropped), so you only need to wrap a URL by hand when you have a non-lightning endpoint **from elsewhere**: URL-encode the full upstream endpoint (including query params) and append it to `https://l402.space/`, then `fetch` that. The same path works for x402 and MPP upstreams alike — the gateway detects the upstream's protocol itself. An x402/MPP endpoint that supports lightning natively needs no bridge at all; just `fetch` it directly.
 
 ```bash
-npx -y @getalby/cli@0.9.0 fetch "https://l402.space/<url-encoded-upstream-url>" --max-amount <amount> --currency BTC --unit sats --network lightning
+npx -y @getalby/cli@0.10.0 fetch "https://l402.space/<url-encoded-upstream-url>" --max-amount <amount> --currency BTC --unit sats --network lightning
 ```
 
 Your HTTP method and body pass through unchanged. For full details and current behavior, read [https://l402.space/llms.txt](https://l402.space/llms.txt).
 
 ## Discovering Paid Services
 
-The `discover` command searches [402index.io](https://402index.io) for paid API endpoints across all supported rails — L402, x402, and MPP. Do not filter by rail unless explicitly told by the human. Lightning-native services can be paid with `fetch` directly; for non-lightning services (x402/USDC, MPP/Tempo), pay them from your lightning wallet via the bridge described above.
+The `discover` command searches [402index.io](https://402index.io) for paid API endpoints across all supported rails — L402, x402, and MPP. Every result is payable in sats — just pass its URL to `fetch`. Do not filter by rail unless explicitly told by the human.
 
 ### When to use discover
 
@@ -137,10 +138,10 @@ The `discover` command searches [402index.io](https://402index.io) for paid API 
 ### Discover → Fetch flow
 
 1. **Discover** — find services matching the capability gap
-2. **Evaluate** — check price, health status, and reliability from the results
+2. **Evaluate** — check price, health status, and reliability from the results (health checks can be stale — a "degraded" service may work fine, so don't exclude a good match on health status alone)
 3. **Fetch** — pay and consume the service:
    ```bash
-   npx -y @getalby/cli@0.9.0 fetch -X POST -b '{"model":"gpt-image-1","prompt":"a mountain cabin at sunset","size":"1024x1024"}' "<service-url>"
+   npx -y @getalby/cli@0.10.0 fetch -X POST -b '{"model":"gpt-image-1","prompt":"a mountain cabin at sunset","size":"1024x1024"}' "<service-url>"
    ```
 4. **Report** — tell the user what was purchased, the cost, and the result
 
@@ -167,16 +168,16 @@ If no NWC connection secret is present, guide the user to connect their wallet. 
 
 ```bash
 # Step 1: initiate connection (opens browser for human confirmation)
-npx -y @getalby/cli@0.9.0 auth https://my.albyhub.com --app-name MyApp
+npx -y @getalby/cli@0.10.0 auth https://my.albyhub.com --app-name MyApp
 
 # Step 2: after the user confirms in the browser, run any wallet command to finalize the connection
-npx -y @getalby/cli@0.9.0 get-balance
+npx -y @getalby/cli@0.10.0 get-balance
 ```
 
 ### Fallback: connect command (for wallets that provide a connection secret directly)
 
 ```bash
-npx -y @getalby/cli@0.9.0 connect "<connection-secret>"
+npx -y @getalby/cli@0.10.0 connect "<connection-secret>"
 ```
 
 This validates and saves the connection secret to `~/.alby-cli/connection-secret.key`. Use `--force` to overwrite an existing connection. Alternatively, set the `NWC_URL` environment variable. **NEVER paste or share the connection secret in chat.**
@@ -206,3 +207,4 @@ Offer a few starter prompts to help the user get going:
 | Connection failed / timeout | Wallet unreachable or relay down | Check wallet is online, retry |
 | Insufficient balance | Not enough sats | Fund the wallet |
 | 402 payment failed | Invoice expired or amount too high | Retry; adjust maximum spend amount if needed |
+| 402 payment interrupted / failed after paying | Wallet timeout or upstream error mid-payment | Follow the `paymentRecovery` instructions in the error output (`lookup-invoice`, then `--resume` or `--credentials`) — do not re-run blindly |

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alby-bitcoin-payments
-description: teaches agents how to use @getalby/cli to operate a bitcoin lightning wallet via Nostr Wallet Connect (NIP-47). Use whenever the user wants to send or receive money, pay an invoice, check wallet balance, create invoices, convert between fiat and sats, retry an HTTP request that returned 402 Payment Required, or discover paid API services. Pays HTTP 402 resources across all major payment protocols — L402, x402, and MPP and all main networks (USDC on Base, Solana, Tempo) — from the lightning wallet. Pays to any on-chain cryptocurrency/stablecoin address (e.g. USDC/USDT).
+description: teaches agents how to use @getalby/cli to operate a bitcoin lightning wallet via Nostr Wallet Connect (NIP-47). Use whenever the user wants to send or receive money, pay an invoice, check wallet balance, create invoices, convert between fiat and sats, retry an HTTP request that returned 402 Payment Required, or discover paid API services. Pays HTTP 402 resources across all major payment protocols — L402, x402, and MPP and all main networks (USDC on Base, Solana, Tempo) — from the lightning wallet. Also supports atomic swaps to any on-chain cryptocurrency/stablecoin address (e.g. USDC/USDT).
 license: MIT-0
 metadata:
   author: getAlby


### PR DESCRIPTION
## What

Updates the skill for [Alby CLI v0.10.0](https://github.com/getAlby/cli/releases/tag/v0.10.0) (skill version 1.4.0 → 1.5.0, all CLI pins bumped to `@getalby/cli@0.10.0`).

- **Discover across all protocols** (getAlby/cli#49): `discover` now returns L402, x402, and MPP services with non-lightning results pre-wrapped in the l402.space bridge URL and unpayable rails dropped — every result is payable in sats via `fetch`. The non-lightning section now reflects this: manual bridge-wrapping is only needed for non-lightning endpoints obtained outside `discover` (wording aligned with #28).
- **402 payment recovery** (getAlby/cli#59): documents that an interrupted `fetch` exits with either a `credentials` value (paid — re-run with `--credentials`) or a `paymentRecovery` object (`lookup-invoice` + `--resume`), so agents follow the recovery instructions instead of blindly re-running and risking a double payment. Added a matching Common Issues row.
- **Health filter removed from discover defaults** (getAlby/cli#60): the Evaluate step now warns that health checks can be stale and a "degraded" service shouldn't be excluded on that alone.
- Skill description now names L402/x402/MPP and the supported networks so agents activate the skill for non-lightning 402s.

`fetch --dry-run` (getAlby/cli#56) is intentionally not documented, per the note in that PR.

## Test

- Verified `--dry-run`, `--credentials`, and `--resume` against the live `npx -y @getalby/cli@0.10.0 fetch --help` output.
- Bridge/discover behavior cross-checked against the v0.10.0 source (`discover.ts` pre-wraps bridgeable rails; `fetch` suggests the bridge but never auto-redirects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Alby Bitcoin payment guidance to use CLI version 0.10.0.
  * Expanded instructions for handling interrupted HTTP 402 payments, including recovery options.
  * Clarified support for HTTP 402 payments across major payment protocols and non-Lightning services.
  * Updated wallet setup, discovery, fetching, and troubleshooting examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->