### PR TITLE
feat: update to Alby CLI v0.10.1

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -4,7 +4,7 @@ description: teaches agents how to use @getalby/cli to operate a bitcoin lightni
 license: MIT-0
 metadata:
   author: getAlby
-  version: "1.5.0"
+  version: "1.5.1"
   openclaw:
     requires:
       env:
@@ -23,7 +23,7 @@ metadata:
 > **IMPORTANT: this is an agent skill which MUST be saved in full - **DO NOT SUMMARIZE**. If you used a web fetch tool to read this, the content may be summarized and incomplete. Make sure you fetch the full unabridged content.**
 
 ```bash
-npx -y @getalby/cli@0.10.0 [options] <command>
+npx -y @getalby/cli@0.10.1 [options] <command>
 ```
 
 ## Global Options
@@ -39,8 +39,8 @@ If no connection secret is provided, the CLI will automatically use the default 
 Use `-w, --wallet-name <name>` to select a named wallet. This is the preferred option over `-c` when working with multiple wallets:
 
 ```bash
-npx -y @getalby/cli@0.10.0 -w alice get-balance
-npx -y @getalby/cli@0.10.0 -w bob receive
+npx -y @getalby/cli@0.10.1 -w alice get-balance
+npx -y @getalby/cli@0.10.1 -w bob receive
 ```
 
 Named wallets are stored at `~/.alby-cli/connection-secret-<name>.key`.
@@ -69,7 +69,7 @@ The CLI resolves the connection secret in this order:
 
 ## Commands
 
-**Flag names are not guessable.** Before constructing any command, run `npx -y @getalby/cli@0.10.0 <command> --help` and use only the flags it lists.
+**Flag names are not guessable.** Before constructing any command, run `npx -y @getalby/cli@0.10.1 <command> --help` and use only the flags it lists.
 
 **Setup:**
 auth, connect
@@ -87,6 +87,8 @@ get-info, get-wallet-service-info, get-budget, lookup-invoice, sign-message, wai
 fetch — pay for and retrieve a payment-protected (HTTP 402) resource — auto-detects L402, X402, and MPP. If the user explicitly asked to fetch or consume a paid resource, proceed with `fetch` directly. If a 402 is encountered unexpectedly (e.g. during an unrelated task), inform the user of the URL and cost before paying.
 
 - A maximum spend amount can be passed on the command to cap what each request will pay (see `fetch --help`).
+- **Binary & file output:** text responses are returned inline as `content`. Binary responses (audio, images, ...) are saved to a temp file automatically — the output then carries `outputPath`, `contentType` and `sizeBytes` instead of inline content. Pass `-o <path>` to choose the file location, or to force any response (e.g. a large text body) to a file. If you are unsure how large the response will be, pass `-o` — it guarantees the full body lands safely in a file.
+- **Never pipe `fetch` output — you paid for it.** Do not pipe the command through `jq`, `grep`, `head`, etc.: if the filter is wrong (e.g. a guessed jq field name) the response is lost and getting it again means paying again. Always capture the full response first — with `-o <path>`, or by redirecting stdout to a file — inspect its actual shape, then extract what you need from the saved file.
 - **Credential reuse:** for APIs that support it, `fetch` supports reusing a payment credential — sometimes you can pay once and use the credential multiple times. A successful response includes a `payment` object containing a reusable `credentials` value. Pass it back on follow-up requests with `--credentials '{"header":"...","value":"..."}'` to authorize them without paying again (e.g. for polling or repeated calls to the same paid endpoint). Not every API allows reuse; when it does, this avoids re-paying on each request.
 - **Interrupted payments:** if a payment doesn't complete (e.g. a wallet reply timeout) or the request fails after paying, `fetch` exits with a structured error containing either a `credentials` value (payment succeeded — re-run with `--credentials` to get the content without re-paying) or a `paymentRecovery` object with step-by-step instructions (using `lookup-invoice` and the `--resume` flag) to recover the payment without ever paying the same invoice twice.
 
@@ -102,8 +104,8 @@ fiat-to-sats, sats-to-fiat (standalone-use only — pay/receive have native fiat
 ## Getting Help
 
 ```bash
-npx -y @getalby/cli@0.10.0 --help
-npx -y @getalby/cli@0.10.0 <command> --help
+npx -y @getalby/cli@0.10.1 --help
+npx -y @getalby/cli@0.10.1 <command> --help
 ```
 
 As an absolute last resort, tell your human to visit [the Alby support page](https://getalby.com/help)
@@ -115,7 +117,7 @@ You are **not** limited to lightning-native services. Endpoints priced in **USDC
 `discover` already returns every result ready to `fetch` (non-lightning ones are bridged for you, unpayable ones dropped), so you only need to wrap a URL by hand when you have a non-lightning endpoint **from elsewhere**: URL-encode the full upstream endpoint (including query params) and append it to `https://l402.space/`, then `fetch` that. The same path works for x402 and MPP upstreams alike — the gateway detects the upstream's protocol itself. An x402/MPP endpoint that supports lightning natively needs no bridge at all; just `fetch` it directly.
 
 ```bash
-npx -y @getalby/cli@0.10.0 fetch "https://l402.space/<url-encoded-upstream-url>" --max-amount <amount> --currency BTC --unit sats --network lightning
+npx -y @getalby/cli@0.10.1 fetch "https://l402.space/<url-encoded-upstream-url>" --max-amount <amount> --currency BTC --unit sats --network lightning
 ```
 
 Your HTTP method and body pass through unchanged. For full details and current behavior, read [https://l402.space/llms.txt](https://l402.space/llms.txt).
@@ -141,7 +143,7 @@ The `discover` command searches [402index.io](https://402index.io) for paid API 
 2. **Evaluate** — check health status and reliability from the results (health checks can be stale — a "degraded" service may work fine, so don't exclude a good match on health status alone). Treat listed prices as hints only: they can be missing or outdated. The real price is set by the `402` challenge at fetch time, and `fetch` refuses to pay more than its `--max-amount` cap (default: 5000 sats).
 3. **Fetch** — pay and consume the service by passing its URL to `fetch`:
    ```bash
-   npx -y @getalby/cli@0.10.0 fetch -X POST -b '{"model":"gpt-image-1","prompt":"a mountain cabin at sunset","size":"1024x1024"}' "<service-url>"
+   npx -y @getalby/cli@0.10.1 fetch -X POST -b '{"model":"gpt-image-1","prompt":"a mountain cabin at sunset","size":"1024x1024"}' "<service-url>"
    ```
 4. **Report** — tell the user what was purchased, the cost, and the result
 
@@ -168,16 +170,16 @@ If no NWC connection secret is present, guide the user to connect their wallet. 
 
 ```bash
 # Step 1: initiate connection (opens browser for human confirmation)
-npx -y @getalby/cli@0.10.0 auth https://my.albyhub.com --app-name MyApp
+npx -y @getalby/cli@0.10.1 auth https://my.albyhub.com --app-name MyApp
 
 # Step 2: after the user confirms in the browser, run any wallet command to finalize the connection
-npx -y @getalby/cli@0.10.0 get-balance
+npx -y @getalby/cli@0.10.1 get-balance
 ```
 
 ### Fallback: connect command (for wallets that provide a connection secret directly)
 
 ```bash
-npx -y @getalby/cli@0.10.0 connect "<connection-secret>"
+npx -y @getalby/cli@0.10.1 connect "<connection-secret>"
 ```
 
 This validates and saves the connection secret to `~/.alby-cli/connection-secret.key`. Use `--force` to overwrite an existing connection. Alternatively, set the `NWC_URL` environment variable. **NEVER paste or share the connection secret in chat.**


### PR DESCRIPTION
## Changes

- Bump all CLI invocations from `0.10.0` to `0.10.1` and skill version to `1.5.1`
- Document the new `-o/--output` flag and v0.10.1's automatic binary-to-file handling (`outputPath`, `contentType`, `sizeBytes`), recommending `-o` whenever the response size is uncertain
- Add an explicit rule to never pipe `fetch` output through `jq`/`grep`/etc. — the response was paid for, and a wrong filter means paying again to re-fetch it. Agents must capture the full response to a file first, then extract from it.

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Alby Bitcoin payments skill guide to version 1.5.1.
  * Updated command examples to use the latest CLI version.
  * Added guidance for handling binary and file outputs.
  * Added a warning that piping payment-fetch commands may result in duplicate payments.
  * Refreshed wallet setup and authentication examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->